### PR TITLE
Update the download of get-pip.py

### DIFF
--- a/addons/python/build-python
+++ b/addons/python/build-python
@@ -55,7 +55,7 @@ else
       # http://pythonhosted.org/setuptools/merge.html
       # python3 distribute_setup.py
       # use get-pip instead from pypa
-      curl -O https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py
+      curl -O https://bootstrap.pypa.io/get-pip.py
       python3 get-pip.py
     else
       echo Using python
@@ -63,7 +63,7 @@ else
       # obsolate, there is no more distribute_setup.py
       # install pip
       echo "Easy install pip..."
-      curl -O https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py
+      curl -O https://bootstrap.pypa.io/get-pip.py
       python get-pip.py
     fi
 


### PR DESCRIPTION
Otherwise our builds are failing with

```
You're using an outdated location for the get-pip.py script, please use the one available from https://bootstrap.pypa.io/get-pip.py
```